### PR TITLE
Add IncludeRules / ExcludeRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Automated Visual Testing for [React Storybook](https://github.com/kadirahq/react-storybook) using [Screener.io](https://screener.io).
 
-Screener-Storybook will use your existing Storybook stories as visual test cases, and run them against [Screener's](https://screener.io) automated visual testing service. Get visual regression tests across your React components with no coding!
+Screener-Storybook will use your existing Storybook stories as visual test cases, and run them against [Screener's](https://screener.io) automated visual testing service. Get visual regression tests across your React components with no additional coding!
 
 ### Installation
 
@@ -25,3 +25,38 @@ $ node node_modules/screener-storybook/bin/init.js -k <SCREENER_API_KEY>
 ```
 $ npm run test-storybook
 ```
+
+### Additional Configuration Options
+
+**Note:** Screener will automatically set `build` and `branch` options if you are using one of the following CI tools: Jenkins, CircleCI, Travis CI, Codeship, Drone, Bitbucket Pipelines, Semaphore.
+
+- **build:** Build number from your CI tool. Screener will auto-generate a Build number if not provided.
+- **branch:** Current branch name for your repo
+- **resolution:** Screen resolution to use. Defaults to `1024x768`
+- **ignore:** Comma-delimited string of CSS Selectors that represent areas to be ignored. Example: `.qa-ignore-date, .qa-ignore-ad`
+- **includeRules:** Optional array of strings or RegExp expressions to filter states by. Rules are matched against state name. All matching states will be kept.
+    - Example:
+    ```
+    includeRules: [
+      'State name',
+      /^Component/
+    ]
+    ```
+- **excludeRules:** Optional array of strings or RegExp expressions to filter states by. Rules are matched against state name. All matching states will be removed.
+    - Example:
+    ```
+    excludeRules: [
+      'State name',
+      /^Component/
+    ]
+    ```
+- **diffOptions:** Visual diff options to control validations.
+    - Example:
+    ```
+    diffOptions: {
+      structure: true,
+      layout: true,
+      style: true,
+      content: true
+    }
+    ```

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prompt": "~1.0.0",
     "react-dom": "~15.4.1",
     "require-hijack": "~1.2.1",
-    "screener-runner": "^0.1.2",
+    "screener-runner": "^0.2.0",
     "semver": "~5.3.0"
   },
   "devDependencies": {

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,5 +1,6 @@
 var validate = require('./validate');
 var Runner = require('screener-runner');
+var cloneDeep = require('lodash/cloneDeep');
 var omit = require('lodash/omit');
 var url = require('url');
 
@@ -27,7 +28,7 @@ var transformToStates = function(storybook, baseUrl) {
 
 exports.run = function(config) {
   // create copy of config
-  config = JSON.parse(JSON.stringify(config));
+  config = cloneDeep(config);
   return validate.storybookConfig(config)
     .then(function() {
       if (config.storybookPort) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -21,6 +21,14 @@ exports.storybookConfig = function(value) {
     branch: Joi.string().max(100),
     resolution: Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
     ignore: Joi.string(),
+    includeRules: Joi.array().min(0).items(
+      Joi.string(),
+      Joi.object().type(RegExp)
+    ),
+    excludeRules: Joi.array().min(0).items(
+      Joi.string(),
+      Joi.object().type(RegExp)
+    ),
     diffOptions: Joi.object().keys({
       structure: Joi.boolean(),
       layout: Joi.boolean(),

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -62,6 +62,17 @@ describe('screener-storybook/src/runner', function() {
         });
     });
 
+    it('should pass through includeRules and excludeRules', function() {
+      var testConfig = JSON.parse(JSON.stringify(configWithPort));
+      testConfig.includeRules = ['include', /^include/];
+      testConfig.excludeRules = ['exclude', /^exclude/];
+      return StorybookRunner.run(testConfig)
+        .then(function(runnerConfig) {
+          expect(runnerConfig.includeRules).to.deep.equal(['include', /^include/]);
+          expect(runnerConfig.excludeRules).to.deep.equal(['exclude', /^exclude/]);
+        });
+    });
+
     it('should transform config data to expected screener-runner format with screenerUrl set', function() {
       return StorybookRunner.run(configWithUrl)
         .then(function(runnerConfig) {

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -67,9 +67,30 @@ describe('screener-storybook/src/validate', function() {
     });
 
     it('should allow adding optional fields', function() {
-      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookPort: 6006, storybook: [], build: 'build', branch: 'branch', resolution: '1280x1024', ignore: 'ignore', diffOptions: {}})
+      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookPort: 6006, storybook: [], build: 'build', branch: 'branch', resolution: '1280x1024', ignore: 'ignore', includeRules: [], excludeRules: [], diffOptions: {}})
         .catch(function() {
           throw new Error('Should not be here');
+        });
+    });
+
+    it('should allow include/exclude rules that are strings', function() {
+      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookPort: 6006, storybook: [], includeRules: ['string'], excludeRules: ['string']})
+        .catch(function() {
+          throw new Error('Should not be here');
+        });
+    });
+
+    it('should allow include/exclude rules that are regex expressions', function() {
+      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookPort: 6006, storybook: [], includeRules: [/^string$/], excludeRules: [/^string$/]})
+        .catch(function() {
+          throw new Error('Should not be here');
+        });
+    });
+
+    it('should throw error when include/exclude rules are not in array', function() {
+      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookPort: 6006, storybook: [], includeRules: 'string', excludeRules: 'string'})
+        .catch(function(err) {
+          expect(err.message).to.equal('child "includeRules" fails because ["includeRules" must be an array]');
         });
     });
 


### PR DESCRIPTION
## Changes

- Add optional includeRules / excludeRules configuration options
- Pass new options to `screener-runner`
- Validate option formats. Allow rules to be a string or RegExp expression
- Change to use lodash `cloneDeep` method to make object copies
- Update default resolution to `1024x768`
- Update Unit Tests
- Update README docs

## How to Test

```
$ npm test
```
