### PR TITLE
Fix: Storybook object returning with extra properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,23 @@
 var Promise = require('bluebird');
+var pick = require('lodash/pick');
 
 exports.staticStorybook = Promise.promisify(require('./storybook/static'));
 
 exports.getStorybook = function() {
-  return require('./storybook');
+  var storybook = require('./storybook');
+  // make copy and remove methods
+  storybook = JSON.parse(JSON.stringify(storybook));
+  if (storybook instanceof Array) {
+    // remove any extra properties
+    storybook = storybook.map(function(kind) {
+      var obj = pick(kind, ['kind', 'stories']);
+      obj.stories = obj.stories.map(function(story) {
+        return pick(story, ['name']);
+      });
+      return obj;
+    });
+  }
+  return storybook;
 };
 
 exports.run = require('./runner').run;


### PR DESCRIPTION
## Changes

- getStorybook is returning stories with additional properties and methods, such as `render`, which is breaking validation. Normalize and clean returned storybook array before passing to runner.