### PR TITLE
Add Steps for Interaction Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,48 @@ $ node node_modules/screener-storybook/bin/init.js -k <SCREENER_API_KEY>
 $ npm run test-storybook
 ```
 
+### Testing Interactions
+
+To test interactions, you can add `steps` to your existing Storybook stories. Each `step` is an instruction to interact with the component. This is useful for clicking buttons, filling out forms, and getting your components into the proper visual state to test. This also keeps your stories and interaction test code in the same place.
+
+To add `steps` to a story, wrap your component within a `Screener` component, and pass it a `steps` prop. The `steps` can then be generated using our fluent API. Step methods with selectors have built-in waits to simplify test flow creation.
+
+Here is an example:
+
+```
+import {Screener, Steps} from 'screener-storybook';
+
+storiesOf('MyComponent', module)
+  .add('default', () => {
+    const steps = new Steps()
+      .click('.selector')
+      .snapshot('name')
+      .end();
+    return (
+      <Screener steps={steps}/>
+        <MyComponent />
+      </Screener>
+    );
+  });
+  ```
+
+The following step methods are currently available:
+
+- `click(selector)`: this will click on the first element matching the provided css selector.
+- `snapshot(name)`: this will capture a Screener snapshot.
+- `hover(selector)`: this will move the mouse over the first element matching the provided css selector.
+- `setValue(selector, value)`: this will set the value of the input field matching the provided css selector.
+- `executeScript(code)`: this executes custom JS code against the client browser the test is running in.
+- `ignore(selector)`: this ignores all elements matching the provided css selector(s).
+- `wait(ms)`: this will pause execution for the specified number of ms.
+- `wait(selector)`: this will wait until the element matching the provided css selector is present.
+- `end()`: this will return the steps to be run.
+
+**Note 1:** The `Screener` component **must** be the top-most component returned within a story.
+
+**Note 2:** When adding `Steps` using the fluent API, you **must** end the method chain with `end()`.
+
+
 ### Additional Configuration Options
 
 **Note:** Screener will automatically set `build` and `branch` options if you are using one of the following CI tools: Jenkins, CircleCI, Travis CI, Codeship, Drone, Bitbucket Pipelines, Semaphore.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^15.0.0",
     "react-dom": "~15.4.1",
     "require-hijack": "~1.2.1",
-    "screener-runner": "^0.2.0",
+    "screener-runner": "^0.3.0",
     "semver": "~5.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "parse-git-config": "~1.1.1",
     "portfinder": "~1.0.10",
     "prompt": "~1.0.0",
+    "react": "^15.0.0",
     "react-dom": "~15.4.1",
     "require-hijack": "~1.2.1",
     "screener-runner": "^0.2.0",

--- a/src/runner.js
+++ b/src/runner.js
@@ -20,6 +20,9 @@ var transformToStates = function(storybook, baseUrl) {
         url: iframeUrl,
         name: component.kind + ': ' + story.name
       };
+      if (story.steps && story.steps instanceof Array) {
+        state.steps = story.steps;
+      }
       states.push(state);
     });
   });

--- a/src/screener.js
+++ b/src/screener.js
@@ -1,0 +1,12 @@
+var React = require('react');
+
+var Screener = function(p) {
+  return React.createElement('div', null, p.children);
+};
+
+Screener.propTypes = {
+  children: React.PropTypes.any,
+  steps: React.PropTypes.array
+};
+
+module.exports = Screener;

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,5 +1,6 @@
 var Joi = require('joi');
 var Promise = require('bluebird');
+var stepsSchema = require('screener-runner/src/validate').stepsSchema;
 
 exports.storybookConfig = function(value) {
   var schema = Joi.object().keys({
@@ -12,7 +13,8 @@ exports.storybookConfig = function(value) {
         kind: Joi.string().required(),
         stories: Joi.array().min(1).items(
           Joi.object().keys({
-            name: Joi.string().required()
+            name: Joi.string().required(),
+            steps: stepsSchema
           })
         ).required()
       })

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -31,6 +31,35 @@ var configWithUrl = {
   ]
 };
 
+var configWithSteps = {
+  apiKey: 'api-key',
+  projectRepo: 'repo',
+  storybookUrl: 'http://url.com/',
+  storybook: [
+    {
+      kind: 'Component 1',
+      stories: [
+        {
+          name: 'default',
+          steps: [
+            {
+              type: 'clickElement',
+              locator: {
+                type: 'css selector',
+                value: 'selector'
+              }
+            },
+            {
+              type: 'saveScreenshot',
+              name: 'name'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
 var runnerMock = {
   run: function(runnerConfig) {
     return Promise.resolve(runnerConfig);
@@ -83,6 +112,35 @@ describe('screener-storybook/src/runner', function() {
               {
                 url: 'http://url.com/iframe.html?dataId=0&selectedKind=Component%201&selectedStory=default',
                 name: 'Component 1: default'
+              }
+            ]
+          });
+        });
+    });
+
+    it('should include steps when transforming to states', function() {
+      return StorybookRunner.run(configWithSteps)
+        .then(function(runnerConfig) {
+          expect(runnerConfig).to.deep.equal({
+            apiKey: 'api-key',
+            projectRepo: 'repo',
+            states: [
+              {
+                url: 'http://url.com/iframe.html?dataId=0&selectedKind=Component%201&selectedStory=default',
+                name: 'Component 1: default',
+                steps: [
+                  {
+                    type: 'clickElement',
+                    locator: {
+                      type: 'css selector',
+                      value: 'selector'
+                    }
+                  },
+                  {
+                    type: 'saveScreenshot',
+                    name: 'name'
+                  }
+                ]
               }
             ]
           });


### PR DESCRIPTION
## Changes

- Create `Screener` wrapper component
- Expose `Screener` component and `Steps` API
- Extract steps from Storybook object
- Add steps during states transformation
- Update validation to include steps
- Update Unit Tests
- Update README docs with fluent API methods and example

## How to Test

```
$ npm test
```
