### PR TITLE
Add device emulation options to resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ The following step methods are currently available:
 - **build:** Build number from your CI tool. Screener will auto-generate a Build number if not provided.
 - **branch:** Current branch name for your repo
 - **resolution:** Screen resolution to use. Defaults to `1024x768`
+    - Accepts a string in the format: `<width>x<height>`. Example: `1024x768`
+    - Or accepts an object for Device Emulation. Example:
+    ```javascript
+    {
+      deviceName: 'iPhone 6'
+    }
+    ```
+    - deviceName value can be one of: iPhone 4, iPhone 5, iPhone 6, iPhone 6 Plus, iPad, iPad Pro, Galaxy S5, Nexus 4, Nexus 5, Nexus 5X, Nexus 6P, Nexus 7, Nexus 10
+    - deviceOrientation option also available. Can be `portrait` or `landscape`. Defaults to `portrait`.
 - **ignore:** Comma-delimited string of CSS Selectors that represent areas to be ignored. Example: `.qa-ignore-date, .qa-ignore-ad`
 - **includeRules:** Optional array of strings or RegExp expressions to filter states by. Rules are matched against state name. All matching states will be kept.
     - Example:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^15.0.0",
     "react-dom": "~15.4.1",
     "require-hijack": "~1.2.1",
-    "screener-runner": "^0.3.2",
+    "screener-runner": "^0.3.3",
     "semver": "~5.3.0"
   },
   "devDependencies": {

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,6 +1,7 @@
 var Joi = require('joi');
 var Promise = require('bluebird');
 var stepsSchema = require('screener-runner/src/validate').stepsSchema;
+var resolutionSchema = require('screener-runner/src/validate').resolutionSchema;
 
 exports.storybookConfig = function(value) {
   var schema = Joi.object().keys({
@@ -21,7 +22,7 @@ exports.storybookConfig = function(value) {
     ).required(),
     build: Joi.string().max(40),
     branch: Joi.string().max(100),
-    resolution: Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
+    resolution: resolutionSchema,
     ignore: Joi.string(),
     includeRules: Joi.array().min(0).items(
       Joi.string(),

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -97,7 +97,7 @@ describe('screener-storybook/src/validate', function() {
     it('should throw error when resolution in incorrect format', function() {
       return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookPort: 6006, storybook: [], resolution: 'resolution'})
         .catch(function(err) {
-          expect(err.message).to.equal('child "resolution" fails because ["resolution" with value "resolution" fails to match the resolution pattern]');
+          expect(err.message).to.equal('child "resolution" fails because ["resolution" with value "resolution" fails to match the resolution pattern, "resolution" must be an object, "resolution" must be an object]');
         });
     });
 


### PR DESCRIPTION
## Changes

- create `resolutionSchema` validation to support deviceName/deviceOrientation object:
    ```javascript
    {
      deviceName: 'iPhone 6',
      deviceOrientation: 'landscape'
    }
    ```
- Update Unit Tests
- Update README docs with new resolution options

## How to Test

```
$ npm test
```
