### PR TITLE
Add Debug option. Auto-skip invalid story format.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,10 @@ program
   .option('-c, --conf <config-file>', 'Path to Configuration File')
   .option('--build-cmd <build-cmd>', 'Set NPM Command for Building Storybook. Defaults to: build-storybook')
   .option('--static-server-only', 'Start Static Server only for testing purposes')
+  .option('--debug', 'Enable debug mode')
   .parse(process.argv);
+
+console.log('\nscreener-storybook v' + pjson.version + '\n');
 
 if (program.staticServerOnly) {
   StorybookRunner.staticStorybook(program.buildCmd)
@@ -50,8 +53,11 @@ if (program.staticServerOnly) {
       }
       // get storybook object, and add to config
       config.storybook = StorybookRunner.getStorybook();
+      if (program.debug) {
+        console.log('DEBUG: config.storybook', JSON.stringify(config.storybook, null, 2));
+      }
       // run test against Screener
-      return StorybookRunner.run(config);
+      return StorybookRunner.run(config, program);
     })
     .then(function(response) {
       console.log(response);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 var Promise = require('bluebird');
+var compact = require('lodash/compact');
+var colors = require('colors/safe');
 
 exports.staticStorybook = Promise.promisify(require('./storybook/static'));
 
@@ -6,10 +8,22 @@ exports.getStorybook = function() {
   var storybook = require('./storybook');
   if (storybook instanceof Array) {
     // make copy and extract steps
-    storybook = storybook.map(function(kind) {
+    storybook = compact(storybook.map(function(kind) {
+      // check kind format
+      if (typeof kind !== 'object' || !kind.kind || !kind.stories || !(kind.stories instanceof Array) || kind.stories.length === 0) {
+        console.log(colors.yellow('WARNING: Invalid kind format. Skipping.'));
+        console.log(kind);
+        return null;
+      }
       return {
         kind: kind.kind,
-        stories: kind.stories.map(function(story) {
+        stories: compact(kind.stories.map(function(story) {
+          // check story format
+          if (typeof story !== 'object' || !story.name) {
+            console.log(colors.yellow('WARNING: Invalid story format in \'' + kind.kind + '\'. Skipping story.'));
+            console.log(kind);
+            return null;
+          }
           var obj = {
             name: story.name
           };
@@ -26,9 +40,9 @@ exports.getStorybook = function() {
             }
           }
           return obj;
-        })
+        }))
       };
-    });
+    }));
   }
   return storybook;
 };

--- a/src/runner.js
+++ b/src/runner.js
@@ -29,7 +29,7 @@ var transformToStates = function(storybook, baseUrl) {
   return states;
 };
 
-exports.run = function(config) {
+exports.run = function(config, options) {
   // create copy of config
   config = cloneDeep(config);
   return validate.storybookConfig(config)
@@ -46,6 +46,9 @@ exports.run = function(config) {
       config.states = transformToStates(config.storybook, config.storybookUrl);
       // remove storybook-specific fields
       config = omit(config, ['storybook', 'storybookPort', 'storybookUrl']);
+      if (options && options.debug) {
+        console.log('DEBUG: config', JSON.stringify(config, null, 2));
+      }
       // send storybook states to screener-runner
       return Runner.run(config);
     });


### PR DESCRIPTION
## Changes

- Add optional `--debug` CLI flag
- Output additional logs to aid with debugging
- Check and skip invalid story formats
- Output warnings when story format is invalid
- Output version number

## How to Test

```
$ npm test
```
