### PR TITLE
Fix dependencies injected into browser window object

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -24,9 +24,9 @@ console.log(colors.bold('\nscreener-storybook v' + pjson.version + '\n'));
 
 if (program.staticServerOnly) {
   StorybookRunner.staticStorybook(program.buildCmd)
-    .then(function(port) {
-      if (port) {
-        console.log('Static Storybook server started on http://localhost:' + port);
+    .then(function(result) {
+      if (result && result.port) {
+        console.log('Static Storybook server started on http://localhost:' + result.port);
       } else {
         throw new Error('Static Storybook server could not be started.');
       }
@@ -47,13 +47,16 @@ if (program.staticServerOnly) {
 
   // start local storybook server
   StorybookRunner.staticStorybook(program.buildCmd, config)
-    .then(function(port) {
-      if (port) {
-        config.storybookPort = port;
-        console.log('Static Storybook server started on http://localhost:' + port);
+    .then(function(result) {
+      if (result && result.port) {
+        config.storybookPort = result.port;
+        console.log('Static Storybook server started on http://localhost:' + result.port);
       }
       // get storybook object, and add to config
-      config.storybook = StorybookRunner.getStorybook();
+      return StorybookRunner.getStorybook(result);
+    })
+    .then(function(storybook) {
+      config.storybook = storybook;
       if (program.debug) {
         console.log('DEBUG: config.storybook', JSON.stringify(config.storybook, null, 2));
       }

--- a/src/index.js
+++ b/src/index.js
@@ -4,47 +4,50 @@ var colors = require('colors/safe');
 
 exports.staticStorybook = Promise.promisify(require('./storybook/static'));
 
-exports.getStorybook = function() {
-  var storybook = require('./storybook');
-  if (storybook instanceof Array) {
-    // make copy and extract steps
-    storybook = compact(storybook.map(function(kind) {
-      // check kind format
-      if (typeof kind !== 'object' || !kind.kind || !kind.stories || !(kind.stories instanceof Array) || kind.stories.length === 0) {
-        console.log(colors.yellow('WARNING: Invalid kind format. Skipping.'));
-        console.log(kind);
-        return null;
-      }
-      return {
-        kind: kind.kind,
-        stories: compact(kind.stories.map(function(story) {
-          // check story format
-          if (typeof story !== 'object' || !story.name || typeof story.name !== 'string') {
-            console.log(colors.yellow('WARNING: Invalid story format in \'' + kind.kind + '\'. Skipping story.'));
+exports.getStorybook = function(options) {
+  var getStorybook = Promise.promisify(require('./storybook'));
+  return getStorybook(options)
+    .then(function(storybook) {
+      if (storybook instanceof Array) {
+        // make copy and extract steps
+        storybook = compact(storybook.map(function(kind) {
+          // check kind format
+          if (typeof kind !== 'object' || !kind.kind || !kind.stories || !(kind.stories instanceof Array) || kind.stories.length === 0) {
+            console.log(colors.yellow('WARNING: Invalid kind format. Skipping.'));
             console.log(kind);
             return null;
           }
-          var obj = {
-            name: story.name
-          };
-          if (typeof story.render === 'function') {
-            try {
-              var result = story.render();
-              // check if <Screener> is top-most component
-              if (result && result.type && result.props && result.type.name === 'Screener') {
-                // get steps prop
-                obj.steps = result.props.steps;
+          return {
+            kind: kind.kind,
+            stories: compact(kind.stories.map(function(story) {
+              // check story format
+              if (typeof story !== 'object' || !story.name || typeof story.name !== 'string') {
+                console.log(colors.yellow('WARNING: Invalid story format in \'' + kind.kind + '\'. Skipping story.'));
+                console.log(kind);
+                return null;
               }
-            } catch (ex) {
-              console.error(ex);
-            }
-          }
-          return obj;
-        }))
-      };
-    }));
-  }
-  return storybook;
+              var obj = {
+                name: story.name
+              };
+              if (typeof story.render === 'function') {
+                try {
+                  var result = story.render();
+                  // check if <Screener> is top-most component
+                  if (result && result.type && result.props && result.type.name === 'Screener') {
+                    // get steps prop
+                    obj.steps = result.props.steps;
+                  }
+                } catch (ex) {
+                  console.error(ex);
+                }
+              }
+              return obj;
+            }))
+          };
+        }));
+      }
+      return storybook;
+    });
 };
 
 exports.run = require('./runner').run;

--- a/src/storybook/index.js
+++ b/src/storybook/index.js
@@ -8,50 +8,94 @@ var runWithRequireContext = require('./require_context');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-var babel = require('babel-core');
-var configDir = './.storybook';
-var polyfillsPath = require.resolve('./default_config/polyfills.js');
-var loadersPath = require.resolve('./default_config/loaders.js');
-var configPath = path.resolve(configDir, 'config.js');
-var babelConfig = loadBabelConfig(configDir);
+module.exports = function(options, callback) {
+  var babel = require('babel-core');
+  var configDir = './.storybook';
+  var polyfillsPath = require.resolve('./default_config/polyfills.js');
+  var loadersPath = require.resolve('./default_config/loaders.js');
+  var configPath = path.resolve(configDir, 'config.js');
+  var babelConfig = loadBabelConfig(configDir);
 
-// cacheDir is webpack babel loader specific. We don't run webpack.
-delete babelConfig.cacheDirectory;
+  // cacheDir is webpack babel loader specific. We don't run webpack.
+  delete babelConfig.cacheDirectory;
 
-require('babel-register')(babelConfig);
-require('babel-polyfill');
+  require('babel-register')(babelConfig);
+  require('babel-polyfill');
 
-// load loaders
-var loaders = require(path.resolve(loadersPath));
+  // load loaders
+  var loaders = require(path.resolve(loadersPath));
 
-Object.keys(loaders).forEach(function(ext) {
-  var loader = loaders[ext];
-  require.extensions['.' + ext] = function(m, filepath) {
-    m.exports = loader(filepath);
+  Object.keys(loaders).forEach(function(ext) {
+    var loader = loaders[ext];
+    require.extensions['.' + ext] = function(m, filepath) {
+      m.exports = loader(filepath);
+    };
+  });
+
+  // load polyfills
+  require(path.resolve(polyfillsPath));
+
+  // set userAgent so storybook knows we're storyshots
+  if (!global.navigator) {
+    global.navigator = {};
+  }
+  global.navigator.userAgent = 'screener';
+
+  // Channel for addons is created by storybook manager from the client side.
+  // We need to polyfill it for the server side.
+  var addons = require('@kadira/storybook-addons').default;
+  var channel = new EventEmitter();
+  addons.setChannel(channel);
+
+  var content = babel.transformFileSync(configPath, babelConfig).code;
+  var contextOpts = {
+    filename: configPath,
+    dirname: path.resolve(configDir),
   };
-});
-
-// load polyfills
-require(path.resolve(polyfillsPath));
-
-// set userAgent so storybook knows we're storyshots
-if (!global.navigator) {
-  global.navigator = {};
-}
-global.navigator.userAgent = 'screener';
-
-// Channel for addons is created by storybook manager from the client side.
-// We need to polyfill it for the server side.
-var addons = require('@kadira/storybook-addons').default;
-var channel = new EventEmitter();
-addons.setChannel(channel);
-
-var content = babel.transformFileSync(configPath, babelConfig).code;
-var contextOpts = {
-  filename: configPath,
-  dirname: path.resolve(configDir),
+  try {
+    runWithRequireContext(content, contextOpts);
+    var storybook = require('@kadira/storybook').getStorybook();
+    callback(null, storybook);
+  } catch(ex) {
+    if (!options || !options.staticPath) return callback(ex);
+    // Exception may be caused by global dependencies injected into browser's Window object.
+    // We are not running through an actual browser, so try JSDom.
+    var jsdom = require('jsdom');
+    var fs = require('fs');
+    var dirPath = path.resolve(options.staticPath, 'static');
+    var previewPath = null;
+    if (fs.existsSync(dirPath)) {
+      var files = fs.readdirSync(dirPath);
+      files.forEach(function(filename) {
+        if (/^preview\.[^\.]+\.bundle\.js$/.test(filename)) {
+          previewPath = path.resolve(dirPath, filename);
+        }
+      });
+    }
+    if (!previewPath) return callback(ex);
+    console.log(ex.message);
+    console.log('Retrying with static build...');
+    // attempt to parse js file and retrieve window object
+    jsdom.env({
+      html: '',
+      src: [fs.readFileSync(previewPath, 'utf-8')],
+      done: function (err, window) {
+        if (err) return callback(err);
+        global.window = window || {};
+        Object.keys(global.window).forEach(function(property) {
+          if (typeof global[property] === 'undefined') {
+            global[property] = window[property];
+          }
+        });
+        // retry
+        try {
+          runWithRequireContext(content, contextOpts);
+          var storybook = require('@kadira/storybook').getStorybook();
+          callback(null, storybook);
+        } catch(ex) {
+          callback(ex);
+        }
+      }
+    });
+  }
 };
-runWithRequireContext(content, contextOpts);
-var storybook = require('@kadira/storybook').getStorybook();
-
-module.exports = storybook;

--- a/src/storybook/static.js
+++ b/src/storybook/static.js
@@ -32,7 +32,10 @@ module.exports = function(buildScriptName, config, callback) {
     // start static web server
     http.createServer(app).listen(port, function(err) {
       if (err) return callback(err);
-      callback(null, port);
+      callback(null, {
+        port: port,
+        staticPath: staticPath
+      });
     });
   });
 };


### PR DESCRIPTION
## Changes

- Update `staticStorybook` callback to return both `port` and `staticPath`
- Change `getStorybook` to return a Promise
- Update `getStorybook` to retry on exception, and run through JSDom to handle global dependencies that may be injected into browser's window object.

## How to Test

```
$ npm test
```
