### PR TITLE
Add failureExitCode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ module.exports = {
       content: true
     }
     ```
+- **failureExitCode:** The exit code to use on failure. Defaults to 1, which will fail a CI build.
+    - To NOT fail a CI build on Screener failure, set to 0. Example:
+    ```javascript
+    failureExitCode: 0
+    ```
 - **browsers:** Optional array of browsers for Cross Browser Testing. Each item in array is an object with `browserName` and `version` properties.
     - Note: `browsers` is dependent on `sauce` being added to configuration.
     - `browserName` and `version` *must* match one of the supported browsers/versions in the browser table below.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react": "^15.0.0",
     "react-dom": "~15.4.1",
     "request": "~2.81.0",
-    "screener-runner": "^0.6.1",
+    "screener-runner": "^0.6.2",
     "semver": "~5.3.0"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,18 +5,6 @@ var pjson = require('../package.json');
 var colors = require('colors/safe');
 var StorybookRunner = require('./index');
 var Promise = require('bluebird');
-var handleError = function(err) {
-  if (program && program.debug && err.stack) {
-    console.error('DEBUG:', err.stack);
-  } else {
-    console.error(err.message || err.toString());
-  }
-  console.error('---');
-  console.error('Exiting Screener Storybook');
-  console.error('Run with --debug flag to log additional information');
-  console.error('Need help? Contact: support@screener.io');
-  process.exit(1);
-};
 
 program
   .version(pjson.version)
@@ -61,4 +49,19 @@ StorybookRunner.startStorybook(config, program)
     console.log(response);
     process.exit();
   })
-  .catch(handleError);
+  .catch(function(err) {
+    if (program && program.debug && err.stack) {
+      console.error('DEBUG:', err.stack);
+    } else {
+      console.error(err.message || err.toString());
+    }
+    console.error('---');
+    console.error('Exiting Screener Storybook');
+    console.error('Run with --debug flag to log additional information');
+    console.error('Need help? Contact: support@screener.io');
+    var exitCode = 1;
+    if (config && typeof config.failureExitCode === 'number') {
+      exitCode = config.failureExitCode;
+    }
+    process.exit(exitCode);
+  });

--- a/src/validate.js
+++ b/src/validate.js
@@ -47,7 +47,8 @@ exports.storybookConfig = function(value) {
       style: Joi.boolean(),
       content: Joi.boolean()
     }),
-    sauce: sauceSchema
+    sauce: sauceSchema,
+    failureExitCode: Joi.number().integer().min(0).max(255).default(1)
   }).without('resolutions', ['resolution']).with('browsers', ['sauce']).required();
   var validator = Promise.promisify(Joi.validate);
   return validator(value, schema);

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -101,6 +101,22 @@ describe('screener-storybook/src/validate', function() {
         });
     });
 
+    describe('validate.failureExitCode', function() {
+      it('should allow setting to 0', function() {
+        return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookConfigDir: '.storybook', storybookPort: 6006, storybook: [], failureExitCode: 0})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should error when setting above 255', function() {
+        return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookConfigDir: '.storybook', storybookPort: 6006, storybook: [], failureExitCode: 256})
+          .catch(function(err) {
+            expect(err.message).to.equal('child "failureExitCode" fails because ["failureExitCode" must be less than or equal to 255]');
+          });
+      });
+    });
+
     describe('validate.browsers', function() {
       it('should error when browsers is empty', function() {
         return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookConfigDir: '.storybook', storybookPort: 6006, storybook: [], browsers: []})


### PR DESCRIPTION
## Changes

- Add new `failureExitCode` config option
- Add validation rules for new `failureExitCode` option
- Update unit tests
- Update README

## How to Test

```
$ npm test
```
