### PR TITLE
Support Storybook V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@kadira/storybook": "^2.17.0",
     "react": "^0.14.7 || ^15.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Changes

- Remove storybook peerDependency, as peer dependencies cannot be conditional (storybook v2 package is called @kadira/storybook, and v3 is called @storybook/react)
- Check for either v2 or v3 storybook packages
- Update Storybook version verification for 2.17+, < 4.x
- Update getStorybook to be called on correct storybook version

## How to Test

```
$ npm test
```
