### PR TITLE
Check for Storybook with require. Deprecate version checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "react": "^15.0.0",
     "react-dom": "~15.4.1",
     "request": "~2.81.0",
-    "screener-runner": "^0.7.3",
-    "semver": "~5.3.0"
+    "screener-runner": "^0.7.3"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/src/check.js
+++ b/src/check.js
@@ -1,39 +1,36 @@
-var semver = require('semver');
+var resolveModule = function(path) {
+  var modulePath = null;
+  try {
+    modulePath = require.resolve(path);
+  } catch(ex) { /* module not found */ }
+  return modulePath;
+};
 
-var storybookCheck = function(pjson) {
-  if (!pjson || (!pjson.dependencies && !pjson.devDependencies)) {
-    throw new Error('No dependencies found in package.json');
-  }
+var storybookCheck = function() {
+  // look for Storybook module
   var deps = [
-    (pjson.dependencies || {})['@storybook/react']  || (pjson.devDependencies || {})['@storybook/react'],
-    (pjson.dependencies || {})['@storybook/vue']    || (pjson.devDependencies || {})['@storybook/vue'],
-    (pjson.dependencies || {})['@kadira/storybook'] || (pjson.devDependencies || {})['@kadira/storybook']
+    resolveModule('@storybook/react'),
+    resolveModule('@storybook/vue'),
+    resolveModule('@kadira/storybook')
   ];
   var result = {};
   if (deps[0]) {
     result = {
       app: 'react',
-      version: 3,
-      range: deps[0]
+      version: 3
     };
   } else if (deps[1]) {
     result = {
       app: 'vue',
-      version: 3,
-      range: deps[1]
+      version: 3
     };
   } else if (deps[2]) {
     result = {
       app: 'react',
-      version: 2,
-      range: deps[2]
+      version: 2
     };
   } else {
-    throw new Error('Storybook module not found in package.json');
-  }
-  // check storybook version range
-  if ((!semver.satisfies('2.17.0', result.range) && !semver.ltr('2.17.0', result.range)) || !semver.gtr('4.0.0', result.range)) {
-    throw new Error('Storybook version must be >= 2.17.0 and < 4.x');
+    throw new Error('Storybook module not found');
   }
   return result;
 };

--- a/src/storybook.js
+++ b/src/storybook.js
@@ -25,7 +25,7 @@ exports.server = function(config, options, callback) {
   } else {
     // check storybook module
     try {
-      var pkg = storybookCheck(require(process.cwd() + '/package.json'));
+      var pkg = storybookCheck();
       storybookApp = pkg.app;
       storybookVersion = pkg.version;
     } catch(ex) {

--- a/test/check.spec.js
+++ b/test/check.spec.js
@@ -1,99 +1,62 @@
 var expect = require('chai').expect;
-var storybookCheck = require('../src/check');
+var rewire = require('rewire');
+var storybookCheck = rewire('../src/check');
 
 describe('screener-storybook/src/check', function() {
 
-  it('should error if there are no dependencies found', function() {
-    try {
-      storybookCheck();
-    } catch (err) {
-      expect(err.toString()).to.equal('Error: No dependencies found in package.json');
-    }
-    try {
-      storybookCheck({});
-    } catch (err) {
-      expect(err.toString()).to.equal('Error: No dependencies found in package.json');
-    }
-  });
-
   it('should return react storybook v3', function() {
-    var pjson = {
-      devDependencies: {
-        '@storybook/react': '^3.1.3'
+    storybookCheck.__set__('require', {
+      resolve: function(path) {
+        if (path === '@storybook/react') {
+          return true;
+        }
       }
-    };
-    var result = storybookCheck(pjson);
+    });
+    var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'react',
-      version: 3,
-      range: '^3.1.3'
+      version: 3
     });
   });
 
   it('should return vue storybook v3', function() {
-    var pjson = {
-      devDependencies: {
-        '@storybook/vue': '^3.0.0-alpha.0'
+    storybookCheck.__set__('require', {
+      resolve: function(path) {
+        if (path === '@storybook/vue') {
+          return true;
+        }
       }
-    };
-    var result = storybookCheck(pjson);
-    expect(result).to.deep.equal({
-      app: 'vue',
-      version: 3,
-      range: '^3.0.0-alpha.0'
     });
-  });
-
-  it('should return vue storybook v3', function() {
-    var pjson = {
-      devDependencies: {
-        '@storybook/vue': '^3.0.0-alpha.0'
-      }
-    };
-    var result = storybookCheck(pjson);
+    var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'vue',
-      version: 3,
-      range: '^3.0.0-alpha.0'
+      version: 3
     });
   });
 
   it('should return react storybook v2', function() {
-    var pjson = {
-      devDependencies: {
-        '@kadira/storybook': '^2.35.0'
+    storybookCheck.__set__('require', {
+      resolve: function(path) {
+        if (path === '@kadira/storybook') {
+          return true;
+        }
       }
-    };
-    var result = storybookCheck(pjson);
+    });
+    var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'react',
-      version: 2,
-      range: '^2.35.0'
+      version: 2
     });
   });
 
   it('should error when storybook not found', function() {
-    var pjson = {
-      dependencies: {},
-      devDependencies: {}
-    };
+    storybookCheck.__set__('require', {
+      resolve: function() {}
+    });
     try {
-      storybookCheck(pjson);
+      storybookCheck();
     } catch (err) {
-      expect(err.toString()).to.equal('Error: Storybook module not found in package.json');
-    }
-  });
-
-  it('should error when storybook version is out of range', function() {
-    var pjson = {
-      devDependencies: {
-        '@storybook/react': '^4.0.0'
-      }
-    };
-    try {
-      storybookCheck(pjson);
-    } catch (err) {
-      expect(err.toString()).to.equal('Error: Storybook version must be >= 2.17.0 and < 4.x');
+      expect(err.toString()).to.equal('Error: Storybook module not found');
     }
   });
 


### PR DESCRIPTION
### Changes

- Use require to check for Storybook module, instead of inspecting package.json
- Deprecate version checking (was only useful for version < 2.17, which is no longer supported)
- Update unit tests

Fixes https://github.com/screener-io/screener-storybook/issues/33