### PR TITLE
Add Keys and keys/focus step methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ The following step methods are currently available. Methods with selectors have 
 - `hover(selector)`: this will move the mouse over the first element matching the provided css selector.
 - `mouseDown(selector)`: this will press and hold the mouse button over the first element matching the provided css selector.
 - `mouseUp(selector)`: this will release the mouse button. `selector` is optional.
+- `focus(selector)`: this will set cursor focus on the first element matching the provided css selector.
 - `setValue(selector, value)`: this will set the value of the input field matching the provided css selector.
+- `keys(selector, keys)`: this will send the provided keys to the first element matching the provided css selector.
 - `executeScript(code)`: this executes custom JS code against the client browser the test is running in.  The `code` parameter is a **string**.
 - `ignore(selector)`: this ignores all elements matching the provided css selector(s).
 - `wait(ms)`: this will pause execution for the specified number of ms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.10.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
-      "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q=="
+      "version": "8.10.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.34.tgz",
+      "integrity": "sha512-alypNiaAEd0RBGXoWehJ2gchPYCITmw4CYBoB5nDlji8l8on7FsklfdfIs4DDmgpKLSX3OF3ha6SV+0W7cTzUA=="
     },
     "abab": {
       "version": "1.0.4",
@@ -888,7 +888,7 @@
     },
     "finalhandler": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
       "integrity": "sha1-LEANjUUwk1vCMlScX6OF7Afeb80=",
       "requires": {
         "debug": "2.2.0",
@@ -1566,7 +1566,7 @@
     "ngrok": {
       "version": "github:screener-io/ngrok#ca2e459b401722ae8c033491aaacaf87125cd238",
       "requires": {
-        "@types/node": "8.10.30",
+        "@types/node": "8.10.34",
         "async": "2.6.1",
         "decompress-zip": "0.3.1",
         "lock": "0.1.4",
@@ -3110,7 +3110,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -3379,9 +3379,9 @@
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "screener-runner": {
-      "version": "0.10.15",
-      "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.10.15.tgz",
-      "integrity": "sha512-0Kq6t2yMnEXYqmEIuWIdfkGVb63aNmj6BMtpZ9ovx6KgGwzLzxE5Q+XUbl8EpgqBGMXXqwJ9eT08V+nMbEDPlA==",
+      "version": "0.10.16",
+      "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.10.16.tgz",
+      "integrity": "sha512-FPOrP3nPiVv8V/g+yqg2S8fGqINnOA9/9UtZsYQDC+N72P4rH9KRa+ewFBA+2RoKr4ojUVPqDRnzQM579s2WSg==",
       "requires": {
         "bluebird": "3.4.7",
         "colors": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^16.0.0",
     "request": "^2.87.0",
     "requestretry": "~1.12.2",
-    "screener-runner": "^0.10.15"
+    "screener-runner": "^0.10.16"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/src/screener.js
+++ b/src/screener.js
@@ -18,5 +18,6 @@ Screener.defaultProps = {
 
 exports.default = Screener;
 exports.Steps = require('screener-runner/src/steps');
+exports.Keys = require('screener-runner/src/keys');
 
 module.exports = extend(exports.default, exports);


### PR DESCRIPTION
## Changes

- Update to latest `screener-runner`, which includes Keys and new step types: `keys` and `focus`
- Update unit tests
- Update README

## Resolves

https://github.com/screener-io/screener-storybook/issues/75
https://github.com/screener-io/screener-storybook/issues/74

## How to Test

```
$ npm test
```
