### PR TITLE
Adds prerelease check for StoryBook

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -4,9 +4,12 @@ var checkApp = function(app) {
   try {
     var packagePath = require.resolve(app.path + '/package.json');
     var packageVersion = semver.major(require(packagePath).version);
+    var packagePreRelease = semver.prerelease(require(packagePath).version);
+
     return {
       app: app.name,
-      version: app.version || packageVersion
+      version: app.version || packageVersion,
+      isPreRelease: Array.isArray(packagePreRelease)
     };
   } catch(ex) {
     // module not found

--- a/src/storybook.js
+++ b/src/storybook.js
@@ -37,6 +37,7 @@ var resourceLoader = function(prefix, callback) {
 exports.server = function(config, options, callback) {
   var storybookApp;
   var storybookVersion;
+  var isPreRelease;
   if (!config || !config.storybookConfigDir) {
     return callback(new Error('Error: \'storybookConfigDir\' not found in config file.'));
   }
@@ -52,6 +53,7 @@ exports.server = function(config, options, callback) {
       var pkg = storybookCheck();
       storybookApp = pkg.app;
       storybookVersion = pkg.version;
+      isPreRelease = pkg.isPreRelease;
     } catch(ex) {
       return callback(ex);
     }
@@ -89,7 +91,7 @@ exports.server = function(config, options, callback) {
       args.push('--static-dir');
       args.push(config.storybookStaticDir);
     }
-    if (storybookVersion === 4) {
+    if (storybookVersion === 4 && !isPreRelease) {
       args.push('--ci');
     }
     console.log('\nStarting Storybook server...');

--- a/test/check.spec.js
+++ b/test/check.spec.js
@@ -18,7 +18,27 @@ describe('screener-storybook/src/check', function() {
     var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'react',
-      version: 4
+      version: 4,
+      isPreRelease: false
+    });
+  });
+
+  it('should return react storybook preRelease', function() {
+    var tmpRequire = function() {
+      return {version: '4.0.0-alpha.3'};
+    };
+    tmpRequire.resolve = function(path) {
+      if (path === '@storybook/react/package.json') {
+        return 'package.json';
+      }
+      throw new Error();
+    };
+    storybookCheck.__set__('require', tmpRequire);
+    var result = storybookCheck();
+    expect(result).to.deep.equal({
+      app: 'react',
+      version: 4,
+      isPreRelease: true
     });
   });
 
@@ -36,7 +56,8 @@ describe('screener-storybook/src/check', function() {
     var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'react',
-      version: 3
+      version: 3,
+      isPreRelease: false
     });
   });
 
@@ -54,7 +75,8 @@ describe('screener-storybook/src/check', function() {
     var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'vue',
-      version: 4
+      version: 4,
+      isPreRelease: false
     });
   });
 
@@ -72,7 +94,8 @@ describe('screener-storybook/src/check', function() {
     var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'angular',
-      version: 4
+      version: 4,
+      isPreRelease: false
     });
   });
 
@@ -90,7 +113,8 @@ describe('screener-storybook/src/check', function() {
     var result = storybookCheck();
     expect(result).to.deep.equal({
       app: 'react',
-      version: 2
+      version: 2,
+      isPreRelease: false
     });
   });
 


### PR DESCRIPTION
**Problem:**
In running Screener-storybook with an alpha version of Storybook, I found that https://github.com/screener-io/screener-storybook/blob/master/src/storybook.js#L92 was failing after an error:
```
error: unknown option `--ci'
```
I identified the above by adding the `--debug` flag to during the test run.

On further investigating I found that that the version check didn't account for pre release which was causing an issue as we are currently on an alpha release of SB.

**Solution:**
Adding a pre-release semver check conditional to the storybook.js conditional that was throwing the error resolves this.
