### PR TITLE
Update request retry strategy to handle 404 status

### DIFF
--- a/src/storybook.js
+++ b/src/storybook.js
@@ -125,7 +125,10 @@ exports.server = function(config, options, callback) {
     // wait for storybook server to be ready
     setTimeout(function() {
       baseUrl = 'http://localhost:' + port;
-      requestRetry.get(baseUrl + '/', function(err, response, body) {
+      var retryStrategy = function(err, response) {
+        return requestRetry.RetryStrategies.HTTPOrNetworkError(err, response) || (response && response.statusCode === 404);
+      };
+      requestRetry.get(baseUrl + '/', {retryStrategy: retryStrategy}, function(err, response, body) {
         if (err) return callback(err);
         if (response.statusCode != 200 || !body) {
           return callback(new Error('Error loading Storybook'));


### PR DESCRIPTION
## Changes

- Update request retry strategy to include 404 status code when Storybook dev server slow to start, and initially returns 404s.

## How to Test

```
$ npm test
```
