### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types='react' />
+
 declare module 'screener-storybook/src/screener' {
   export type Key =
     | 'alt'
@@ -22,7 +24,42 @@ declare module 'screener-storybook/src/screener' {
     isPassword: boolean
   }
 
-  export interface Steps {
+  export interface Locator {
+    type: 'css selector';
+    value: string;
+  }
+
+  export type StepType = 'url' |
+    'saveScreenshot' |
+    'cropScreenshot' |
+    'clickElement' |
+    'moveTo' |
+    'clickAndHoldElement' |
+    'releaseElement' |
+    'setElementText' |
+    'sendKeys' |
+    'executeScript' |
+    'ignoreElements' |
+    'pause' |
+    'waitForElementPresent' |
+    'waitForElementNotPresent' |
+    'cssAnimations';
+
+  export interface Step {
+    type: StepType;
+    locator?: Locator;
+    url?: string;
+    name?: string;
+    text?: string;
+    isPassword?: boolean;
+    keys?: string;
+    code?: string;
+    isAsync?: boolean;
+    waitTime?: number;
+    isEnabled?: boolean;
+  }
+
+  export class Steps {
     url(url: string): Steps;
     click(selector: string): Steps;
     cssAnimations(enabled: boolean): Steps;
@@ -35,20 +72,25 @@ declare module 'screener-storybook/src/screener' {
     setValue(selector: string, value: string, options?: SetValueOpts): Steps;
     executeScript(code: string, isAsync?: boolean): Steps;
     ignore(selector: string): Steps;
-    wait(val: number | string): Steps;
+    wait(selector: string): Steps;
+    wait(ms: number): Steps;
     waitForNotFound(selector: string): Steps;
     rtl(): Steps;
     ltr(): Steps;
-    end(): object[];
+    end(): Step[];
   }
 
-  // tslint:disable-next-line
-  export class Steps implements Steps {}
-
   export interface ScreenerProps {
-    steps?: Steps;
+    /**
+     * Steps to run. Build using a `Steps` object and convert to an array using `.end()`.
+     * @example new Steps().hover('.foo').snapshot('hovered').end()
+     */
+    steps?: Step[];
     isScreenerComponent?: boolean;
   }
 
-  export default class Screener extends React.Component<ScreenerProps> {}
+  export default class Screener extends React.Component<ScreenerProps> {
+    static Steps: typeof Steps;
+    static Keys: typeof Keys;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,20 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
       "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA=="
     },
+    "@types/prop-types": {
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
+      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw=="
+    },
+    "@types/react": {
+      "version": "16.7.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.18.tgz",
+      "integrity": "sha512-Tx4uu3ppK53/iHk6VpamMP3f3ahfDLEVt3ZQc8TFm30a1H3v9lMsCntBREswZIW/SKrvJjkb3Hq8UwO6GREBng==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -506,6 +520,11 @@
       "requires": {
         "cssom": "0.3.4"
       }
+    },
+    "csstype": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.0.tgz",
+      "integrity": "sha512-by8hi8BlLbowQq0qtkx54d9aN73R9oUW20HISpka5kmgsR9F7nnxgfsemuR2sdCKZh+CDNf5egW9UZMm4mgJRg=="
     },
     "d": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/react": "*",
     "bluebird": "~3.4.6",
     "colors": "~1.1.2",
     "commander": "~2.9.0",


### PR DESCRIPTION
After adding a reference in my project to the screener-storybook typings, I started getting compiler errors because the typings didn't reflect some (valid) ways we were using the package. This is what I did locally to get the typings working.

Most notably, based on the examples and our usage it appears that `ScreenerProps.steps` should be an array of step objects, not a `Steps` object. Also added proper typings for the step objects, a reference to `@types/react`, and references to `Steps` and `Keys` in the default export.