### PR TITLE
Increase retry attempts to handle slow storybook startup

### DIFF
--- a/src/storybook.js
+++ b/src/storybook.js
@@ -130,7 +130,7 @@ exports.server = function(config, options, callback) {
       var retryStrategy = function(err, response) {
         return requestRetry.RetryStrategies.HTTPOrNetworkError(err, response) || (response && response.statusCode === 404);
       };
-      requestRetry.get(baseUrl + '/', {retryStrategy: retryStrategy}, function(err, response, body) {
+      requestRetry.get(baseUrl + '/', {retryStrategy: retryStrategy, maxAttempts: 30}, function(err, response, body) {
         if (err) return callback(err);
         if (response.statusCode != 200 || !body) {
           return callback(new Error('Error loading Storybook'));


### PR DESCRIPTION
## Changes

- Large Storybook projects startup slow with SB5
- Increase retry attempts

## How to Test

```
$ npm test
```
