### PR TITLE
Support Static Storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ npm run test-storybook
 - [Testing Interactions](#testing-interactions)
 - [Testing Responsive Designs](#testing-responsive)
 - [Cross Browser Testing](#cross-browser-testing)
+- [Testing with Static Storybook App](#static-build)
 - [Additional Configuration Options](#config-options)
 
 ---
@@ -237,6 +238,34 @@ module.exports = {
 
 
 
+### <a name="static-build"></a>Testing with Static Storybook App
+
+To run Screener against a static Storybook build, instead of starting the Storybook Dev server, follow these setup instructions:
+
+1. Update your Storybook config file (`.storybook/config.js`), and add the following code to the end of the file:
+
+```javascript
+if (typeof window === 'object') {
+  window.__screener_storybook__ = require('@storybook/react').getStorybook;
+}
+```
+
+2. Re-export your Storybook project into a static web app: `npm run build-storybook`
+
+
+3. Update your `screener.config.js` file, and add the `storybookStaticBuildDir` option with its value set to your static Storybook folder:
+
+```javascript
+// screener.config.js
+module.exports = {
+  ...
+
+  storybookStaticBuildDir: 'storybook-static'
+};
+```
+
+
+
 
 ### <a name="config-options"></a>Additional Configuration Options
 
@@ -263,6 +292,7 @@ module.exports = {
 - **baseBranch:** Optional branch name of your project's base branch (e.g. master). Set this option when developing using feature branches to:
     - automatically compare and accept changes when merging a feature branch into the base branch, or when rebasing a feature branch.
     - automatically pull the initial baseline of UI states for a feature branch from this base branch.
+- **storybookStaticBuildDir:** Optional path to exported static Storybook app. When this is used, tests will be run against the static Storybook app only. See above section "Testing with Static Storybook App" for setup instructions.
 - **includeRules:** Optional array of RegExp expressions to filter states by. Rules are matched against state name. All matching states will be kept.
     - Example:
     ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,6 +1774,23 @@
         "is-stream": "1.1.0"
       }
     },
+    "node-static": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.11.tgz",
+      "integrity": "sha512-zfWC/gICcqb74D9ndyvxZWaI1jzcoHmf4UTHWQchBNuNMxdBLJMDiUgZ1tjGLEIe/BMhj2DxKD8HOuc2062pDQ==",
+      "requires": {
+        "colors": "1.1.2",
+        "mime": "1.6.0",
+        "optimist": "0.6.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -2858,6 +2875,22 @@
       "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
     },
     "optionator": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "joi": "~10.0.2",
     "js-yaml": "^3.13.1",
     "lodash": "~4.17.11",
+    "node-static": "~0.7.11",
     "prop-types": "^15.6.0",
     "puppeteer": "~1.17.0",
     "react": "^16.0.0",

--- a/src/runner.js
+++ b/src/runner.js
@@ -50,7 +50,7 @@ exports.run = function(config, options) {
       // generate config format expected by screener-runner
       config.states = transformToStates(config.storybook, localUrl, config.storybookPreview);
       // remove storybook-specific fields
-      config = omit(config, ['storybook', 'storybookConfigDir', 'storybookStaticDir', 'storybookPort', 'storybookApp', 'storybookVersion', 'storybookBinPath', 'storybookPreview']);
+      config = omit(config, ['storybook', 'storybookConfigDir', 'storybookStaticDir', 'storybookStaticBuildDir', 'storybookPort', 'storybookApp', 'storybookVersion', 'storybookBinPath', 'storybookPreview']);
       if (options && options.debug) {
         console.log('DEBUG: config', JSON.stringify(config, null, 2));
       }

--- a/src/validate.js
+++ b/src/validate.js
@@ -13,6 +13,7 @@ exports.storybookConfig = function(value) {
     projectRepo: Joi.string().max(100).required(),
     storybookConfigDir: Joi.string().required(),
     storybookStaticDir: Joi.string(),
+    storybookStaticBuildDir: Joi.string(),
     storybookPort: Joi.number().required(),
     storybookPreview: Joi.string().required(),
     storybook: Joi.array().min(0).items(

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -114,6 +114,7 @@ describe('screener-storybook/src/runner', function() {
     it('should remove storybook-specific props', function() {
       var testConfig = JSON.parse(JSON.stringify(configWithPort));
       testConfig.storybookStaticDir = '/static';
+      testConfig.storybookStaticBuildDir = 'storybook-static';
       testConfig.storybookApp = 'react';
       testConfig.storybookVersion = 3;
       testConfig.storybookBinPath = '/path';
@@ -122,6 +123,7 @@ describe('screener-storybook/src/runner', function() {
           expect(runnerConfig).to.not.have.property('storybook');
           expect(runnerConfig).to.not.have.property('storybookConfigDir');
           expect(runnerConfig).to.not.have.property('storybookStaticDir');
+          expect(runnerConfig).to.not.have.property('storybookStaticBuildDir');
           expect(runnerConfig).to.not.have.property('storybookPort');
           expect(runnerConfig).to.not.have.property('storybookApp');
           expect(runnerConfig).to.not.have.property('storybookVersion');

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -67,7 +67,7 @@ describe('screener-storybook/src/validate', function() {
     });
 
     it('should allow adding optional fields', function() {
-      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookConfigDir: '.storybook', storybookStaticDir: './public', storybookPort: 6006, storybookPreview: '/preview.html', storybook: [], build: 'build', branch: 'branch', commit: 'commit', resolution: '1280x1024', cssAnimations: true, ignore: 'ignore', hide: 'hide', includeRules: [], excludeRules: [], initialBaselineBranch: 'master', baseBranch: 'master', alwaysAcceptBaseBranch: true, diffOptions: {compareSVGDOM: true, minShiftGraphic: 5}, failOnNewStates: true, beforeEachScript: function() {}, ieNativeEvents: true})
+      return validate.storybookConfig({apiKey: 'key', projectRepo: 'repo', storybookConfigDir: '.storybook', storybookStaticDir: './public', storybookStaticBuildDir: 'storybook-static', storybookPort: 6006, storybookPreview: '/preview.html', storybook: [], build: 'build', branch: 'branch', commit: 'commit', resolution: '1280x1024', cssAnimations: true, ignore: 'ignore', hide: 'hide', includeRules: [], excludeRules: [], initialBaselineBranch: 'master', baseBranch: 'master', alwaysAcceptBaseBranch: true, diffOptions: {compareSVGDOM: true, minShiftGraphic: 5}, failOnNewStates: true, beforeEachScript: function() {}, ieNativeEvents: true})
         .catch(function() {
           throw new Error('Should not be here');
         });


### PR DESCRIPTION
## Changes

- Add new option `storybookStaticBuildDir`
- Clean storybook options before sending to screener-runner
- Handle new static build option. Launch web server to serve static files
- Update unit tests
- Update README

## How to Test

```
$ npm test
```
