### PR TITLE
Allow for log config to be passed to Runner

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -5,6 +5,7 @@ var browsersSchema = require('screener-runner/src/validate').browsersSchema;
 var sauceSchema = require('screener-runner/src/validate').sauceSchema;
 var vstsSchema = require('screener-runner/src/validate').vstsSchema;
 var browserStackSchema = require('screener-runner/src/validate').browserStackSchema;
+var ngrokSchema = require('screener-runner/src/validate').ngrokSchema;
 
 exports.storybookConfig = function(value) {
   var schema = Joi.object().keys({
@@ -59,6 +60,7 @@ exports.storybookConfig = function(value) {
       minShiftGraphic: Joi.number().integer().min(0),
       compareSVGDOM: Joi.boolean()
     }),
+    ngrok: ngrokSchema,
     sauce: sauceSchema,
     vsts: vstsSchema,
     browserStack: browserStackSchema,


### PR DESCRIPTION
Allows Screener Storybook to be configured with additional options that are ultimately passed to ngrok.

Shouldn't be merged until https://github.com/screener-io/screener-runner/pull/83 is.