### PR TITLE
fix typings: Add children prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module 'screener-storybook/src/screener' {
   }
 
   export interface ScreenerProps {    
-    children: ReactNode; 
+    children: React.ReactNode; 
     /**
      * Steps to run. Build using a `Steps` object and convert to an array using `.end()`.
      * @example new Steps().hover('.foo').snapshot('hovered').end()

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,8 @@ declare module 'screener-storybook/src/screener' {
     end(): Step[];
   }
 
-  export interface ScreenerProps {
+  export interface ScreenerProps {    
+    children: ReactNode; 
     /**
      * Steps to run. Build using a `Steps` object and convert to an array using `.end()`.
      * @example new Steps().hover('.foo').snapshot('hovered').end()


### PR DESCRIPTION
In React 18, the `React.Component` type no longer includes the `children` prop by default, so it needs to be included explicitly.

See https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions

Without this change the `Screener` component cannot be used in React 18 without TypeScript compilation errors.