### PR TITLE
Fix page loading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.1
+- Fix page loading issue inside headless browser
+
 ## 1.0.0
 
 - Upgrades bluebird and commander dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screener-storybook",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Automated Visual Testing for React Storybook using Screener.io",
   "license": "MIT",
   "main": "./index.js",

--- a/src/storybook.js
+++ b/src/storybook.js
@@ -41,6 +41,7 @@ const VALIDPORTS = [
  */
 const getStorybook = async function (page) {
   // asks storybook to extract preview (mdx?) and story store
+  await page.waitForFunction('"__STORYBOOK_PREVIEW__" in window || "__STORYBOOK_STORY_STORE__" in window');
   await page.waitForFunction(`
     (window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract && window.__STORYBOOK_PREVIEW__.extract()) ||
     (window.__STORYBOOK_STORY_STORE__ && window.__STORYBOOK_STORY_STORE__.extract && window.__STORYBOOK_STORY_STORE__.extract())


### PR DESCRIPTION
I faced the issue: `TimeoutError: Waiting failed: 30000ms exceeded`. It was stuck on this line: https://github.com/screener-io/screener-storybook/blob/f768e7ab7d3f66513b5202317120dd81671a378e/src/storybook.js#L44

I tried to disable headless mode and I found only one error in browser console:
```
Uncaught (in promise) Error: Failed to initialize Storybook.

Do you have an error in your `preview.js`? Check your Storybook's browser console for errors.
```

This error appears only when I use `screener-storybook`. I see no issue if I run Storybook normally or if I build Storybook statically, serve `storybook-static` dir via HTTP and open `/iframe.html`.

This PR offers one-line fix.